### PR TITLE
Add support for existing Lambda resources

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,8 +17,22 @@ jobs:
       - name: Terraform Init
         run: terraform -chdir=terraform init
 
+      - name: Import existing resources
+        if: env.EXISTING_LAMBDA_ROLE != '' || env.EXISTING_LAMBDA_FUNCTION != ''
+        env:
+          EXISTING_LAMBDA_ROLE: ${{ secrets.EXISTING_LAMBDA_ROLE }}
+          EXISTING_LAMBDA_FUNCTION: ${{ secrets.EXISTING_LAMBDA_FUNCTION }}
+        run: |
+          if [ -n "$EXISTING_LAMBDA_ROLE" ]; then
+            terraform -chdir=terraform import aws_iam_role.lambda_exec "$EXISTING_LAMBDA_ROLE"
+            terraform -chdir=terraform import aws_iam_role_policy.lambda_policy "$EXISTING_LAMBDA_ROLE"
+          fi
+          if [ -n "$EXISTING_LAMBDA_FUNCTION" ]; then
+            terraform -chdir=terraform import aws_lambda_function.ema_trading "$EXISTING_LAMBDA_FUNCTION"
+          fi
+
       - name: Terraform Apply
-        run: terraform -chdir=terraform apply -auto-approve -var="webull_username=${{ secrets.WEBULL_USERNAME }}" -var="webull_password=${{ secrets.WEBULL_PASSWORD }}" -var="aws_access_key_id=${{ secrets.AWS_KEY_ID }}" -var="aws_secret_access_key=${{ secrets.AWS_SECRET }}"
+        run: terraform -chdir=terraform apply -auto-approve -var="webull_username=${{ secrets.WEBULL_USERNAME }}" -var="webull_password=${{ secrets.WEBULL_PASSWORD }}" -var="aws_access_key_id=${{ secrets.AWS_KEY_ID }}" -var="aws_secret_access_key=${{ secrets.AWS_SECRET }}" -var="existing_lambda_role_name=${{ secrets.EXISTING_LAMBDA_ROLE }}" -var="existing_lambda_function_name=${{ secrets.EXISTING_LAMBDA_FUNCTION }}"
 
   python:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -33,9 +33,25 @@ README.md
    - `WEBULL_PASSWORD`
    - `AWS_KEY_ID`
    - `AWS_SECRET`
+   - *(optional)* `EXISTING_LAMBDA_ROLE` – name of an IAM role to reuse
+   - *(optional)* `EXISTING_LAMBDA_FUNCTION` – existing Lambda function name
 3. **Push** to `main`—GitHub Actions will:
    - Initialize and apply Terraform (creating Secrets Manager secret).
    - Deploy the Lambda function.
+
+### Reusing Existing Lambda Resources
+
+Set `existing_lambda_role_name` or `existing_lambda_function_name` when you
+already have these resources provisioned. Provide their values via the optional
+GitHub Secrets listed above. The workflow will import the resources into the
+Terraform state before applying changes, allowing the rest of the infrastructure
+to reference them.
+
+Example manual apply:
+```bash
+terraform apply -var="existing_lambda_role_name=my-role" \
+  -var="existing_lambda_function_name=my-func" [...]
+```
 
 ### Provisioning Secrets
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,8 +19,20 @@ resource "aws_secretsmanager_secret_version" "webull" {
 }
 
 resource "aws_iam_role" "lambda_exec" {
+  count              = var.existing_lambda_role_name == "" ? 1 : 0
   name               = "ema_trading_lambda_exec"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+data "aws_iam_role" "existing" {
+  count = var.existing_lambda_role_name != "" ? 1 : 0
+  name  = var.existing_lambda_role_name
+}
+
+locals {
+  lambda_role_arn      = var.existing_lambda_role_name == "" ? aws_iam_role.lambda_exec[0].arn : data.aws_iam_role.existing[0].arn
+  lambda_function_arn  = var.existing_lambda_function_name == "" ? aws_lambda_function.ema_trading[0].arn : data.aws_lambda_function.existing[0].arn
+  lambda_function_name = var.existing_lambda_function_name == "" ? aws_lambda_function.ema_trading[0].function_name : data.aws_lambda_function.existing[0].function_name
 }
 
 data "aws_iam_policy_document" "lambda_assume_role" {
@@ -48,8 +60,9 @@ data "aws_iam_policy_document" "lambda_policy_doc" {
 }
 
 resource "aws_iam_role_policy" "lambda_policy" {
+  count  = var.existing_lambda_role_name == "" ? 1 : 0
   name   = "ema_trading_policy"
-  role   = aws_iam_role.lambda_exec.id
+  role   = aws_iam_role.lambda_exec[0].id
   policy = data.aws_iam_policy_document.lambda_policy_doc.json
 }
 
@@ -59,11 +72,17 @@ data "archive_file" "lambda_zip" {
   output_path = "${path.module}/lambda_package.zip"
 }
 
+data "aws_lambda_function" "existing" {
+  count         = var.existing_lambda_function_name != "" ? 1 : 0
+  function_name = var.existing_lambda_function_name
+}
+
 resource "aws_lambda_function" "ema_trading" {
+  count            = var.existing_lambda_function_name == "" ? 1 : 0
   function_name    = "ema_trading_function"
   handler          = "src.lambda_function.handler"
   runtime          = "python3.9"
-  role             = aws_iam_role.lambda_exec.arn
+  role             = local.lambda_role_arn
   filename         = data.archive_file.lambda_zip.output_path
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
   timeout          = 60
@@ -82,13 +101,13 @@ resource "aws_cloudwatch_event_rule" "schedule" {
 resource "aws_cloudwatch_event_target" "lambda_target" {
   rule      = aws_cloudwatch_event_rule.schedule.name
   target_id = "ema_trading_lambda"
-  arn       = aws_lambda_function.ema_trading.arn
+  arn       = local.lambda_function_arn
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.ema_trading.function_name
+  function_name = local.lambda_function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.schedule.arn
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,5 +1,5 @@
 output "lambda_function_name" {
-  value = aws_lambda_function.ema_trading.function_name
+  value = local.lambda_function_name
 }
 
 output "secret_arn" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,3 +23,15 @@ variable "aws_secret_access_key" {
   description = "AWS secret access key for API calls"
   type        = string
 }
+
+variable "existing_lambda_role_name" {
+  description = "Name of an existing IAM role for the Lambda function"
+  type        = string
+  default     = ""
+}
+
+variable "existing_lambda_function_name" {
+  description = "Name of an existing Lambda function to reuse"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- allow reusing pre-existing IAM role and Lambda function
- update workflow to auto-import existing resources
- document new variables in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492a5bcda88333af7a995dd857da68